### PR TITLE
 added missed LDFLAGS to README and cosmetic change for gcc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Compile (replace Release with Debug for a debug build):
     
     cd ./Release
     export CFLAGS="-I/usr/local/include"
+    export LDFLAGS="-L/usr/local/lib"
     make clean
     make
 

--- a/Release/makefile
+++ b/Release/makefile
@@ -67,7 +67,7 @@ all: siridb-server
 siridb-server: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C Linker'
-	gcc  -o "siridb-server" $(OBJS) $(USER_OBJS) $(LIBS) $(CRYPT) $(UUID) $(LDFLAGS)
+	gcc  -o "siridb-server" $(OBJS) $(USER_OBJS) $(LDFLAGS) $(LIBS) $(CRYPT) $(UUID) 
 	@echo 'Finished building target: $@'
 	@echo ' '
 


### PR DESCRIPTION
Please remove $(LDFLAGS) from all *.mk files to suppress warning
```
clang: warning: argument unused during compilation: '-L/usr/local/lib'
```
LDFLAGS should be used in (Release|Debug)/makefile only