### PR TITLE
Grow shard size to at least the new required size

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+siridb-server (2.0.55-0~cb1) unstable; urgency=medium
+
+  * New upstream release
+    - Fixed bug with growing shard size for log values
+
+ -- Jeroen van der Heijden <jeroen@cesbit.com>  Mon, 27 Jul 2026 14:15:00 +0200
+
 siridb-server (2.0.54-0~cb1) unstable; urgency=medium
 
   * New upstream release

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -6,7 +6,7 @@
 
 #define SIRIDB_VERSION_MAJOR 2
 #define SIRIDB_VERSION_MINOR 0
-#define SIRIDB_VERSION_PATCH 54
+#define SIRIDB_VERSION_PATCH 55
 
 /*
  * Use SIRIDB_VERSION_PRE_RELEASE for alpha release versions.

--- a/itest/test_compression.py
+++ b/itest/test_compression.py
@@ -26,8 +26,8 @@ TIME_PRECISION = 'ms'
 class TestCompression(TestBase):
     title = 'Test compression'
 
-    GEN_POINTS = functools.partial(
-        gen_points, time_precision=TIME_PRECISION)
+    GEN_POINTS = staticmethod(functools.partial(
+        gen_points, time_precision=TIME_PRECISION))
 
     async def _test_series(self, client):
 

--- a/itest/test_expiration.py
+++ b/itest/test_expiration.py
@@ -26,8 +26,8 @@ TIME_PRECISION = 's'
 class TestExpiration(TestBase):
     title = 'Test shard expiration'
 
-    GEN_POINTS = functools.partial(
-        gen_points, n=1, time_precision=TIME_PRECISION)
+    GEN_POINTS = staticmethod(functools.partial(
+        gen_points, n=1, time_precision=TIME_PRECISION))
 
     async def _test_series(self, client):
 

--- a/itest/test_insert.py
+++ b/itest/test_insert.py
@@ -26,8 +26,8 @@ TIME_PRECISION = 'ns'
 class TestInsert(TestBase):
     title = 'Test inserts and response'
 
-    GEN_POINTS = functools.partial(
-        gen_points, n=1, time_precision=TIME_PRECISION)
+    GEN_POINTS = staticmethod(functools.partial(
+        gen_points, n=1, time_precision=TIME_PRECISION))
 
     async def _test_series(self, client):
 

--- a/itest/test_integer_load.py
+++ b/itest/test_integer_load.py
@@ -27,14 +27,14 @@ TIME_PRECISION = 'ms'
 class TestIntegerLoad(TestBase):
     title = 'Test inserts and response'
 
-    GEN_POINTS = functools.partial(
+    GEN_POINTS = staticmethod(functools.partial(
         gen_points,
         tp=int,
         mi=-2**10,
         ma=2**10,
         n=5,
         time_precision=TIME_PRECISION,
-        ts_gap=3)
+        ts_gap=3))
 
     async def select(self, client, series, n):
         series = {s.name: s for s in series}

--- a/itest/test_list.py
+++ b/itest/test_list.py
@@ -26,8 +26,8 @@ TIME_PRECISION = 's'
 class TestList(TestBase):
     title = 'Test list'
 
-    GEN_POINTS = functools.partial(
-        gen_points, n=1, time_precision=TIME_PRECISION)
+    GEN_POINTS = staticmethod(functools.partial(
+        gen_points, n=1, time_precision=TIME_PRECISION))
 
     @default_test_setup(1, time_precision=TIME_PRECISION)
     async def run(self):

--- a/itest/test_select_ns.py
+++ b/itest/test_select_ns.py
@@ -104,8 +104,8 @@ TIME_PRECISION = 'ns'
 class TestSelectNano(TestBase):
     title = 'Test select and aggregate functions (ns)'
 
-    GEN_POINTS = functools.partial(
-        gen_points, n=1, time_precision=TIME_PRECISION)
+    GEN_POINTS = staticmethod(functools.partial(
+        gen_points, n=1, time_precision=TIME_PRECISION))
 
     @default_test_setup(1, time_precision=TIME_PRECISION)
     async def run(self):

--- a/itest/testing/client.py
+++ b/itest/testing/client.py
@@ -48,7 +48,8 @@ class Client:
                                  series,
                                  n=0.01,
                                  timeout=None,
-                                 points=functools.partial(gen_points, n=1)):
+                                 points=staticmethod(
+                                     functools.partial(gen_points, n=1))):
         random.shuffle(series)
 
         n = int(len(series) * n)

--- a/itest/testing/helpers.py
+++ b/itest/testing/helpers.py
@@ -71,7 +71,7 @@ def gen_points(
     return [[ts, random_value(tp, mi, ma)] for ts in timestamps]
 
 
-def gen_data(points=functools.partial(gen_points), n=100):
+def gen_data(points=staticmethod(functools.partial(gen_points)), n=100):
     return {random_series_name(): points() for _ in range(n)}
 
 

--- a/src/siri/db/series.c
+++ b/src/siri/db/series.c
@@ -196,7 +196,6 @@ int siridb_series_add_pcache(
     if (pcache->len > siridb->buffer->len || series->buffer == NULL)
     {
         series->length += pcache->len;
-
         return siridb_shards_add_points(
                 siridb,
                 series,

--- a/src/siri/db/shard.c
+++ b/src/siri/db/shard.c
@@ -122,7 +122,7 @@ static int SHARD_load_idx(
         FILE * fp,
         int is_ts64);
 static inline int SHARD_init_fn(siridb_t * siridb, siridb_shard_t * shard);
-static int SHARD_grow(siridb_shard_t * shard);
+static int SHARD_grow(siridb_shard_t * shard, const size_t required_size);
 static size_t SHARD_write_header(
         siridb_t * siridb,
         siridb_series_t * series,
@@ -655,7 +655,7 @@ size_t siridb_shard_write_points(
     unsigned char * cdata = NULL;
 
     uint_fast32_t i;
-    size_t pos, header_sz;
+    size_t pos, header_sz, requred_size;
 
     if (shard->fp->fp == NULL)
     {
@@ -698,9 +698,10 @@ size_t siridb_shard_write_points(
         dsize = (siridb->time->ts_sz + 8) * len;
     }
 
-    if (shard->len > SHARD_GROW_SZ && (shard->len + dsize + 64 > shard->size))
+    requred_size = shard->len + dsize + 64;
+    if (shard->len > SHARD_GROW_SZ && requred_size > shard->size)
     {
-        SHARD_grow(shard);
+        SHARD_grow(shard, requred_size);
     }
 
     if (fseeko(fp, shard->len, SEEK_SET))
@@ -2128,13 +2129,14 @@ static size_t SHARD_write_header(
 }
 
 
-static int SHARD_grow(siridb_shard_t * shard)
+static int SHARD_grow(siridb_shard_t * shard, const size_t required_size)
 {
     assert (shard->fp);
 
     int buffer_fd = fileno(shard->fp->fp);
+    const size_t num_blocks = required_size / SHARD_GROW_SZ + 1;
 
-    shard->size = ((size_t) (shard->size / SHARD_GROW_SZ) + 2) * SHARD_GROW_SZ;
+    shard->size = num_blocks * SHARD_GROW_SZ;
 
     if (buffer_fd == -1)
     {


### PR DESCRIPTION
Shards used to grow in pre-defined blocks, which are large enough for any amount of points. However, with large log, the required new size might exceed one grow block. 

This pr makes sure always the shard grows with at least the required size.

> Note: It also fixes the partial(..) usage in the test script (required for Python 3.14 or higher)
